### PR TITLE
Add missing header to tests

### DIFF
--- a/rpm/0005-Add-missing-include-to-glib-tests.patch
+++ b/rpm/0005-Add-missing-include-to-glib-tests.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
+Date: Wed, 5 Feb 2025 00:17:47 +0200
+Subject: [PATCH] Add missing include to glib tests
+
+---
+ tests/lib/glib/future/extensions/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/lib/glib/future/extensions/CMakeLists.txt b/tests/lib/glib/future/extensions/CMakeLists.txt
+index 511f01b7f814f6a2f1ecbb108ac210fafd1dee54..e4f41a9a24f43c7f5ec1e687d3a7b0e299991308 100644
+--- a/tests/lib/glib/future/extensions/CMakeLists.txt
++++ b/tests/lib/glib/future/extensions/CMakeLists.txt
+@@ -60,6 +60,7 @@ if(ENABLE_TP_GLIB_TESTS)
+             ${CMAKE_SOURCE_DIR}/tools/glib-ginterface-gen.py
+                 --filename=${CMAKE_CURRENT_BINARY_DIR}/_gen/svc-${spec}
+                 --signal-marshal-prefix=NOT_NEEDED
++                --include='<telepathy-glib/dbus.h>'
+                 --include='<telepathy-glib/dbus-properties-mixin.h>'
+                 --not-implemented-func='tp_dbus_g_method_return_not_implemented'
+                 --allow-unstable

--- a/rpm/telepathy-qt5.spec
+++ b/rpm/telepathy-qt5.spec
@@ -14,6 +14,7 @@ Patch0:     0001-Install-tests.patch
 Patch1:     0002-Remove-assert-which-appears-invalid-for-conference-c.patch
 Patch2:     0003-Use-python3-on-tests-accountmanager.patch
 Patch3:     0004-Fix-build-with-glib-2.72.0-and-newer.patch
+Patch4:     0005-Add-missing-include-to-glib-tests.patch
 
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
@@ -92,13 +93,11 @@ This package contains automated tests and tests.xml
 
 %cmake -DENABLE_TESTS=TRUE -DENABLE_FARSTREAM=TRUE -DENABLE_EXAMPLES=FALSE
 
-
-make %{?_smp_mflags}
+%make_build
 
 tests/mktests.sh > tests/tests.xml
 
 %install
-rm -rf %{buildroot}
 export QT_SELECT=5
 %make_install
 
@@ -111,13 +110,11 @@ export QT_SELECT=5
 %postun farstream -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license COPYING
 %{_libdir}/libtelepathy-qt5.so.*
 %{_libdir}/libtelepathy-qt5-service.so.*
 
 %files devel
-%defattr(-,root,root,-)
 %{_libdir}/libtelepathy-qt5.so
 %{_libdir}/libtelepathy-qt5-service.so
 %{_libdir}/pkgconfig/TelepathyQt5.pc
@@ -128,11 +125,9 @@ export QT_SELECT=5
 %{_libdir}/pkgconfig/TelepathyQt5Service.pc
 
 %files farstream
-%defattr(-,root,root,-)
 %{_libdir}/libtelepathy-qt5-farstream.so.*
 
 %files farstream-devel
-%defattr(-,root,root,-)
 %{_libdir}/libtelepathy-qt5-farstream.so
 %{_includedir}/telepathy-qt5/TelepathyQt/Farstream/*
 %{_libdir}/cmake/TelepathyQt5Farstream/TelepathyQt5FarstreamConfig.cmake
@@ -140,6 +135,5 @@ export QT_SELECT=5
 %{_libdir}/pkgconfig/TelepathyQt5Farstream.pc
 
 %files tests
-%defattr(-,root,root,-)
 /opt/tests/%{name}/*
 


### PR DESCRIPTION
Fixes build with gcc 14 and newer.
Remove not needed defattr from spec.